### PR TITLE
feat: add support for react

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Doppio
 
-A Frappe App to setup and manage single page applications (using Vue 3) on any other custom Frappe App.
+A Frappe App to setup and manage single page applications (using Vue 3 or React) on any other custom Frappe App.
 
 ### Installation
 
@@ -23,21 +23,35 @@ $ bench add-spa --app <app-name> [--tailwindcss]
 
 You will be prompted to enter a name for your single page application, this will be the name of the directory and the URI path at which the application will be served. For instance, if you enter `dashboard` (default), then a folder named `dashboard` will be created inside your app's root directory and the application will be served at `/dashboard`.
 
-You can optionally pass the `--tailwindcss` flag which will also setup tailwindCSS (who doesn't like tailwind!) along with the Vue 3 application.
+You will then be asked to select the framework you prefer: React or Vue.
 
-The above command will do the follwing things:
+You can optionally pass the `--tailwindcss` flag which will also setup tailwindCSS (who doesn't like tailwind!) along with the Vue 3/React application.
 
+The above command will do the following things:
+
+### For Vue 3
 1. Scaffold a new Vue 3 starter application (using [Vite](https://vitejs.dev/))
 
-1. Add and configure Vue router
+2. Add and configure Vue router
 
-1. Link utility and controller files to make the connection with Frappe backend a breeze!
+3. Link utility and controller files to make the connection with Frappe backend a breeze!
 
-1. Configure Vite's proxy options (which will be helpful in development), check the `proxyOptions.js` file to see to what ports the Vite dev server proxies the requests (you frappe bench server).
+4. Configure Vite's proxy options (which will be helpful in development), check the `proxyOptions.js` file to see to what ports the Vite dev server proxies the requests (you frappe bench server).
 
-1. Optionally, installs and set's up tailwindCSS.
+5. Optionally, installs and set up tailwindCSS.
 
-1. Update the `website_route_rules` hook (in `hooks.py` of your app) to handle the routing of this SPA.
+6. Update the `website_route_rules` hook (in `hooks.py` of your app) to handle the routing of this SPA.
+
+### For React
+1. Scaffold a new React starter application (using [Vite](https://vitejs.dev/))
+
+2. Add and configure [frappe-react-sdk](https://github.com/nikkothari22/frappe-react-sdk) to make the connection with Frappe backend a breeze!
+
+3. Configure Vite's proxy options (which will be helpful in development), check the `proxyOptions.js` file to see to what ports the Vite dev server proxies the requests (you frappe bench server).
+
+4. Optionally, installs and set up tailwindCSS.
+
+5. Update the `website_route_rules` hook (in `hooks.py` of your app) to handle the routing of this SPA.
 
 Once the setup is complete, you can `cd` into the SPA directory of your app (e.g. `dashboard`) and run:
 
@@ -66,4 +80,4 @@ If you already have a package.json file with scripts in your app's root director
 
 ### License
 
-Do whatever you want with the code. If you can sell it, go ahead an make some money!
+Do whatever you want with the code. If you can sell it, go ahead and make some money!

--- a/doppio/commands/__init__.py
+++ b/doppio/commands/__init__.py
@@ -4,15 +4,16 @@ from .spa_generator import SPAGenerator
 @click.command("add-spa")
 @click.option("--name", default="dashboard", prompt="Dashboard Name")
 @click.option("--app")
+@click.option('--framework', type=click.Choice(['vue', 'react']), default='vue', prompt='Which framework do you want to use?', help='The framework to use for the SPA')
 @click.option(
 	"--tailwindcss", default=False, is_flag=True, help="Configure tailwindCSS"
 )
-def generate_spa(name, app, tailwindcss):
+def generate_spa(framework, name, app, tailwindcss):
 	if not app:
 		click.echo("Please provide an app with --app")
 		return
 
-	generator = SPAGenerator(name, app, tailwindcss)
+	generator = SPAGenerator(framework, name, app, tailwindcss)
 	generator.generate_spa()
 
 

--- a/doppio/commands/__init__.py
+++ b/doppio/commands/__init__.py
@@ -3,7 +3,7 @@ from .spa_generator import SPAGenerator
 
 @click.command("add-spa")
 @click.option("--name", default="dashboard", prompt="Dashboard Name")
-@click.option("--app")
+@click.option("--app", prompt='App Name')
 @click.option('--framework', type=click.Choice(['vue', 'react']), default='vue', prompt='Which framework do you want to use?', help='The framework to use for the SPA')
 @click.option(
 	"--tailwindcss", default=False, is_flag=True, help="Configure tailwindCSS"

--- a/doppio/commands/boilerplates.py
+++ b/doppio/commands/boilerplates.py
@@ -114,7 +114,7 @@ export default defineConfig({
 PROXY_OPTIONS_BOILERPLATE = """const common_site_config = require('../../../sites/common_site_config.json');
 const { webserver_port } = common_site_config;
 
-module.exports = {
+export default {
 	'^/(app|api|assets|files)': {
 		target: `http://localhost:${webserver_port}`,
 		ws: true,

--- a/doppio/commands/boilerplates.py
+++ b/doppio/commands/boilerplates.py
@@ -86,7 +86,7 @@ export default {
 </script>
 """
 
-VITE_CONFIG_BOILERPLATE = """import path from 'path';
+VUE_VITE_CONFIG_BOILERPLATE = """import path from 'path';
 import { defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
 import proxyOptions from './proxyOptions';
@@ -206,4 +206,69 @@ AUTH_ROUTES_BOILERPLATE = """export default [
 		props: true
 	}
 ]
+"""
+
+REACT_VITE_CONFIG_BOILERPLATE = """import path from 'path';
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react'
+import proxyOptions from './proxyOptions';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+	plugins: [react()],
+	server: {
+		port: 8080,
+		proxy: proxyOptions
+	},
+	resolve: {
+		alias: {
+			'@': path.resolve(__dirname, 'src')
+		}
+	},
+	build: {
+		outDir: '../{{app}}/public/{{name}}',
+		emptyOutDir: true,
+		target: 'es2015',
+	},
+});
+"""
+
+APP_REACT_BOILERPLATE = """import { useState } from 'react'
+import reactLogo from './assets/react.svg'
+import './App.css'
+import { FrappeProvider } from 'frappe-react-sdk'
+function App() {
+  const [count, setCount] = useState(0)
+
+  return (
+    <div className="App">
+      <FrappeProvider>
+        <div>
+      <div>
+        <a href="https://vitejs.dev" target="_blank">
+          <img src="/vite.svg" className="logo" alt="Vite logo" />
+        </a>
+        <a href="https://reactjs.org" target="_blank">
+          <img src={reactLogo} className="logo react" alt="React logo" />
+        </a>
+      </div>
+      <h1>Vite + React + Frappe</h1>
+      <div className="card">
+        <button onClick={() => setCount((count) => count + 1)}>
+          count is {count}
+        </button>
+        <p>
+          Edit <code>src/App.jsx</code> and save to test HMR
+        </p>
+      </div>
+      <p className="read-the-docs">
+        Click on the Vite and React logos to learn more
+      </p>
+      </div>
+      </FrappeProvider>
+    </div>
+  )
+}
+
+export default App
 """

--- a/doppio/commands/spa_generator.py
+++ b/doppio/commands/spa_generator.py
@@ -9,8 +9,9 @@ from .utils import create_file
 
 
 class SPAGenerator:
-	def __init__(self, spa_name, app, add_tailwindcss):
+	def __init__(self, framework, spa_name, app, add_tailwindcss):
 		"""Initialize a new SPAGenerator instance"""
+		self.framework = framework
 		self.app = app
 		self.app_path = Path("../apps") / app
 		self.spa_name = spa_name
@@ -19,12 +20,21 @@ class SPAGenerator:
 
 	def generate_spa(self):
 		click.echo("Generating spa...")
+		if self.framework == "vue":
+			self.initialize_vue_vite_project()
+			self.link_controller_files()
+			self.setup_proxy_options()
+			self.setup_vue_vite_config()
+			self.setup_vue_router()
+			self.create_vue_files()
 
-		self.initialize_vue_vite_project()
-		self.link_controller_files()
-		self.setup_proxy_options()
-		self.setup_vue_router()
-		self.create_vue_files()
+		elif self.framework == "react":
+			self.initialize_react_vite_project()
+			self.setup_proxy_options()
+			self.setup_react_vite_config()
+			self.create_react_files()
+
+		#Common to all frameworks
 		self.update_package_json()
 		self.create_www_directory()
 		self.add_csrf_to_html()
@@ -133,11 +143,12 @@ class SPAGenerator:
 		proxy_options_file: Path = self.spa_path / "proxyOptions.js"
 		create_file(proxy_options_file, PROXY_OPTIONS_BOILERPLATE)
 
+	def setup_vue_vite_config(self):
 		vite_config_file: Path = self.spa_path / "vite.config.js"
 		if not vite_config_file.exists():
 			vite_config_file.touch()
 		with vite_config_file.open("w") as f:
-			boilerplate = VITE_CONFIG_BOILERPLATE.replace("{{app}}", self.app)
+			boilerplate = VUE_VITE_CONFIG_BOILERPLATE.replace("{{app}}", self.app)
 			boilerplate = boilerplate.replace("{{name}}", self.spa_name)
 			f.write(boilerplate)
 
@@ -169,7 +180,7 @@ class SPAGenerator:
 		package_json_path: Path = self.spa_path / "package.json"
 
 		if not package_json_path.exists():
-			print("package.json not found. Please manulally update the build command.")
+			print("package.json not found. Please manually update the build command.")
 			return
 
 		data = {}
@@ -222,3 +233,30 @@ class SPAGenerator:
 
 		with index_html_file_path.open("w") as f:
 			f.write(updated_html)
+		
+	def initialize_react_vite_project(self):
+		# Run "yarn create vite {name} --template react"
+		print("Scaffolding React project...")
+		subprocess.run(
+			["yarn", "create", "vite", self.spa_name, "--template", "react"], cwd=self.app_path
+		)
+
+		# Install router and other npm packages
+		# yarn add frappe-react-sdk socket.io-client@2.4.0
+		print("Installing dependencies...")
+		subprocess.run(
+			["yarn", "add", "frappe-react-sdk", "socket.io-client@^2.4.0"], cwd=self.spa_path
+		)
+	
+	def setup_react_vite_config(self):
+		vite_config_file: Path = self.spa_path / "vite.config.js"
+		if not vite_config_file.exists():
+			vite_config_file.touch()
+		with vite_config_file.open("w") as f:
+			boilerplate = REACT_VITE_CONFIG_BOILERPLATE.replace("{{app}}", self.app)
+			boilerplate = boilerplate.replace("{{name}}", self.spa_name)
+			f.write(boilerplate)
+	
+	def create_react_files(self):
+		app_react = self.spa_path / "src/App.jsx"
+		create_file(app_react, APP_REACT_BOILERPLATE)

--- a/doppio/commands/spa_generator.py
+++ b/doppio/commands/spa_generator.py
@@ -34,7 +34,7 @@ class SPAGenerator:
 			self.setup_react_vite_config()
 			self.create_react_files()
 
-		#Common to all frameworks
+		# Common to all frameworks
 		self.update_package_json()
 		self.create_www_directory()
 		self.add_csrf_to_html()
@@ -44,7 +44,7 @@ class SPAGenerator:
 
 		self.add_routing_rule_to_hooks()
 
-		click.echo(f"Run: cd {self.spa_path.absolute()} && npm run dev")
+		click.echo(f"Run: cd {self.spa_path.absolute().resolve()} && npm run dev")
 		click.echo("to start the development server and visit: http://<site>:8080")
 
 	def setup_tailwindcss(self):
@@ -187,9 +187,9 @@ class SPAGenerator:
 		with package_json_path.open("r") as f:
 			data = json.load(f)
 
-		data["scripts"]["build"] = (
-			f"vite build --base=/assets/{self.app}/{self.spa_name}/ && yarn copy-html-entry"
-		)
+		data["scripts"][
+			"build"
+		] = f"vite build --base=/assets/{self.app}/{self.spa_name}/ && yarn copy-html-entry"
 
 		data["scripts"]["copy-html-entry"] = (
 			f"cp ../{self.app}/public/{self.spa_name}/index.html"
@@ -233,7 +233,7 @@ class SPAGenerator:
 
 		with index_html_file_path.open("w") as f:
 			f.write(updated_html)
-		
+
 	def initialize_react_vite_project(self):
 		# Run "yarn create vite {name} --template react"
 		print("Scaffolding React project...")
@@ -247,7 +247,7 @@ class SPAGenerator:
 		subprocess.run(
 			["yarn", "add", "frappe-react-sdk", "socket.io-client@^2.4.0"], cwd=self.spa_path
 		)
-	
+
 	def setup_react_vite_config(self):
 		vite_config_file: Path = self.spa_path / "vite.config.js"
 		if not vite_config_file.exists():
@@ -256,7 +256,7 @@ class SPAGenerator:
 			boilerplate = REACT_VITE_CONFIG_BOILERPLATE.replace("{{app}}", self.app)
 			boilerplate = boilerplate.replace("{{name}}", self.spa_name)
 			f.write(boilerplate)
-	
+
 	def create_react_files(self):
 		app_react = self.spa_path / "src/App.jsx"
 		create_file(app_react, APP_REACT_BOILERPLATE)


### PR DESCRIPTION
I have added support for React in the Doppio CLI.

Major changes and tasks:
- [x] Add option to select framework while setting up SPA
- [x] Split logic for Vue and React. Some file changes (e.g. proxy options, CSRF) were common.
- [x] Add [frappe-react-sdk](https://github.com/nikkothari22/frappe-react-sdk) for React apps in package.json. This will provide hooks for auth. database, search, file management, API calls and realtime listeners using Socket.io. Also ensure to initialise the library in `App.jsx`.
- [x] Update documentation

I have also added a prompt for the `app` name - in case users do not specify it in the initial command.

Closes #7 