### PR TITLE
fix: added host to vite config to enable external access

### DIFF
--- a/doppio/commands/boilerplates.py
+++ b/doppio/commands/boilerplates.py
@@ -96,6 +96,7 @@ export default defineConfig({
 	plugins: [vue()],
 	server: {
 		port: 8080,
+		host: '0.0.0.0',
 		proxy: proxyOptions
 	},
 	resolve: {
@@ -218,6 +219,7 @@ export default defineConfig({
 	plugins: [react()],
 	server: {
 		port: 8080,
+		host: '0.0.0.0',
 		proxy: proxyOptions
 	},
 	resolve: {


### PR DESCRIPTION
With reference to the issue [#49](https://github.com/NagariaHussain/doppio/issues/49)
I have added `host: 0.0.0.0` to vite js config in `boilerplates.py` file

**Issue:**

The Vue.js/react development server was not accessible from the host machine, when development is done inside the Docker container using frappe docker [frappe_docker](https://github.com/frappe/frappe_docker).

**Fix:**

The Vue.js/react development server is accessible from outside the Docker container. when host:0.0.0.0 is added to vite.config
