### PR TITLE
feat: corrected error on  TailwindCSS setup and visual confirmation i…

### DIFF
--- a/doppio/commands/spa_generator.py
+++ b/doppio/commands/spa_generator.py
@@ -4,240 +4,260 @@ import subprocess
 from pathlib import Path
 from .boilerplates import *
 from .utils import (
-	create_file,
-	add_commands_to_root_package_json,
-	add_routing_rule_to_hooks,
+    create_file,
+    add_commands_to_root_package_json,
+    add_routing_rule_to_hooks,
 )
 
 
 class SPAGenerator:
-	def __init__(self, framework, spa_name, app, add_tailwindcss, typescript):
-		"""Initialize a new SPAGenerator instance"""
-		self.framework = framework
-		self.app = app
-		self.app_path = Path("../apps") / app
-		self.spa_name = spa_name
-		self.spa_path: Path = self.app_path / self.spa_name
-		self.add_tailwindcss = add_tailwindcss
-		self.use_typescript = typescript
+    def __init__(self, framework, spa_name, app, add_tailwindcss, typescript):
+        """Initialize a new SPAGenerator instance"""
+        self.framework = framework
+        self.app = app
+        self.app_path = Path("../apps") / app
+        self.spa_name = spa_name
+        self.spa_path: Path = self.app_path / self.spa_name
+        self.add_tailwindcss = add_tailwindcss
+        self.use_typescript = typescript
 
-		self.validate_spa_name()
+        self.validate_spa_name()
 
-	def validate_spa_name(self):
-		if self.spa_name == self.app:
-			click.echo("Dashboard name must not be same as app name", err=True, color=True)
-			exit(1)
+    def validate_spa_name(self):
+        if self.spa_name == self.app:
+            click.echo(
+                "Dashboard name must not be same as app name", err=True, color=True
+            )
+            exit(1)
 
-	def generate_spa(self):
-		click.echo("Generating spa...")
-		if self.framework == "vue":
-			self.initialize_vue_vite_project()
-			self.link_controller_files()
-			self.setup_proxy_options()
-			self.setup_vue_vite_config()
-			self.setup_vue_router()
-			self.create_vue_files()
+    def generate_spa(self):
+        click.echo("Generating spa...")
+        if self.framework == "vue":
+            self.initialize_vue_vite_project()
+            self.link_controller_files()
+            self.setup_proxy_options()
+            self.setup_vue_vite_config()
+            self.setup_vue_router()
+            self.create_vue_files()
 
-		elif self.framework == "react":
-			self.initialize_react_vite_project()
-			self.setup_proxy_options()
-			self.setup_react_vite_config()
-			self.create_react_files()
+        elif self.framework == "react":
+            self.initialize_react_vite_project()
+            self.setup_proxy_options()
+            self.setup_react_vite_config()
+            self.create_react_files()
 
-		# Common to all frameworks
-		add_commands_to_root_package_json(self.app, self.spa_name)
-		self.create_www_directory()
-		self.add_csrf_to_html()
+        # Common to all frameworks
+        add_commands_to_root_package_json(self.app, self.spa_name)
+        self.create_www_directory()
+        self.add_csrf_to_html()
 
-		if self.add_tailwindcss:
-			self.setup_tailwindcss()
+        if self.add_tailwindcss:
+            self.setup_tailwindcss()
 
-		add_routing_rule_to_hooks(self.app, self.spa_name)
+        add_routing_rule_to_hooks(self.app, self.spa_name)
 
-		click.echo(f"Run: cd {self.spa_path.absolute().resolve()} && npm run dev")
-		click.echo("to start the development server and visit: http://<site>:8080")
+        click.echo(f"Run: cd {self.spa_path.absolute().resolve()} && npm run dev")
+        click.echo("to start the development server and visit: http://<site>:8080")
 
-	def setup_tailwindcss(self):
-		# TODO: Convert to yarn command
-		# npm install -D tailwindcss@latest postcss@latest autoprefixer@latest
-		subprocess.run(
-			[
-				"npm",
-				"install",
-				"-D",
-				"tailwindcss@latest",
-				"postcss@latest",
-				"autoprefixer@latest",
-			],
-			cwd=self.spa_path,
-		)
+    def setup_tailwindcss(self):
+        # TODO: Convert to yarn command
+        # npm install -D tailwindcss@latest postcss@latest autoprefixer@latest
+        subprocess.run(
+            [
+                "npm",
+                "install",
+                "-D",
+                "tailwindcss@latest",
+                "postcss@latest",
+                "autoprefixer@latest",
+            ],
+            cwd=self.spa_path,
+        )
 
-		# npx tailwindcss init -p
-		subprocess.run(["npx", "tailwindcss", "init", "-p"], cwd=self.spa_path)
+        # npx tailwindcss init -p
+        subprocess.run(["npx", "tailwindcss", "init", "-p"], cwd=self.spa_path)
 
-		# Create an index.css file
-		index_css_path: Path = self.spa_path / "src/index.css"
+        # Create an index.css file
+        index_css_path: Path = self.spa_path / "src/index.css"
 
-		# Add boilerplate code
-		INDEX_CSS_BOILERPLATE = """@tailwind base;
+        # Add boilerplate code
+        INDEX_CSS_BOILERPLATE = """@tailwind base;
 @tailwind components;
 @tailwind utilities;
 	"""
 
-		create_file(index_css_path, INDEX_CSS_BOILERPLATE)
+        create_file(index_css_path, INDEX_CSS_BOILERPLATE)
 
-		# Populate content property in tailwind config file
-		# the extension of config can be .js or .ts, so we need to check for both
-		tailwind_config_path: Path = self.spa_path / "tailwind.config.js"
-		if not tailwind_config_path.exists():
-			tailwind_config_path = self.spa_path / "tailwind.config.ts"
+        # Populate content property in tailwind config file
+        # the extension of config can be .js or .ts, so we need to check for both
+        # ✅ Add this block instead
 
-		tailwind_config_path: Path = self.spa_path / "tailwind.config.js"
-		tailwind_config = tailwind_config_path.read_text()
-		tailwind_config = tailwind_config.replace(
-			"content: [],", 'content: ["./src/**/*.{html,jsx,tsx,vue,js,ts}"],'
-		)
-		tailwind_config_path.write_text(tailwind_config)
+        tailwind_config_path: Path = self.spa_path / "tailwind.config.js"
 
-	def create_vue_files(self):
-		app_vue = self.spa_path / "src/App.vue"
-		create_file(app_vue, APP_VUE_BOILERPLATE)
+        if not tailwind_config_path.exists():
+            # Fallback: create a minimal config manually
+            fallback_config = """module.exports = {
+		content: ["./src/**/*.{html,jsx,tsx,vue,js,ts}"],
+		theme: {
+			extend: {},
+		},
+		plugins: [],
+		}
+		"""
+            create_file(tailwind_config_path, fallback_config)
+        else:
+            # Patch the content array if config was created
+            tailwind_config = tailwind_config_path.read_text()
+            tailwind_config = tailwind_config.replace(
+                "content: [],", 'content: ["./src/**/*.{html,jsx,tsx,vue,js,ts}"],'
+            )
+            tailwind_config_path.write_text(tailwind_config)
 
-		views_dir: Path = self.spa_path / "src/views"
-		if not views_dir.exists():
-			views_dir.mkdir()
+    def create_vue_files(self):
+        app_vue = self.spa_path / "src/App.vue"
+        create_file(app_vue, APP_VUE_BOILERPLATE)
 
-		home_vue = views_dir / "Home.vue"
-		login_vue = views_dir / "Login.vue"
+        views_dir: Path = self.spa_path / "src/views"
+        if not views_dir.exists():
+            views_dir.mkdir()
 
-		create_file(home_vue, HOME_VUE_BOILERPLATE)
-		create_file(login_vue, LOGIN_VUE_BOILERPLATE)
+        home_vue = views_dir / "Home.vue"
+        login_vue = views_dir / "Login.vue"
 
-	def setup_vue_router(self):
-		# Setup vue router
-		router_dir_path: Path = self.spa_path / "src/router"
+        create_file(home_vue, HOME_VUE_BOILERPLATE)
+        create_file(login_vue, LOGIN_VUE_BOILERPLATE)
 
-		# Create router directory
-		router_dir_path.mkdir()
+    def setup_vue_router(self):
+        # Setup vue router
+        router_dir_path: Path = self.spa_path / "src/router"
 
-		# Create files
-		router_index_file = router_dir_path / "index.js"
-		create_file(
-			router_index_file, ROUTER_INDEX_BOILERPLATE.replace("{{name}}", self.spa_name)
-		)
+        # Create router directory
+        router_dir_path.mkdir()
 
-		auth_routes_file = router_dir_path / "auth.js"
-		create_file(auth_routes_file, AUTH_ROUTES_BOILERPLATE)
+        # Create files
+        router_index_file = router_dir_path / "index.js"
+        create_file(
+            router_index_file,
+            ROUTER_INDEX_BOILERPLATE.replace("{{name}}", self.spa_name),
+        )
 
-	def initialize_vue_vite_project(self):
-		# Run "yarn create vite {name} --template vue"
-		print("Scafolding vue project...")
-		if self.use_typescript:
-			subprocess.run(
-				["yarn", "create", "vite", self.spa_name, "--template", "vue-ts"], cwd=self.app_path
-			)
-		else:
-			subprocess.run(
-				["yarn", "create", "vite", self.spa_name, "--template", "vue"], cwd=self.app_path
-			)
+        auth_routes_file = router_dir_path / "auth.js"
+        create_file(auth_routes_file, AUTH_ROUTES_BOILERPLATE)
 
-		# Install router and other npm packages
-		# yarn add vue-router@4 socket.io-client@4.5.1
-		print("Installing dependencies...")
-		subprocess.run(
-			["yarn", "add", "vue-router@^4", "socket.io-client@^4.5.1"], cwd=self.spa_path
-		)
+    def initialize_vue_vite_project(self):
+        # Run "yarn create vite {name} --template vue"
+        print("Scafolding vue project...")
+        if self.use_typescript:
+            subprocess.run(
+                ["yarn", "create", "vite", self.spa_name, "--template", "vue-ts"],
+                cwd=self.app_path,
+            )
+        else:
+            subprocess.run(
+                ["yarn", "create", "vite", self.spa_name, "--template", "vue"],
+                cwd=self.app_path,
+            )
 
-	def link_controller_files(self):
-		# Link controller files in main.js/main.ts
-		print("Linking controller files...")
-		main_js: Path = self.app_path / (
-			f"{self.spa_name}/src/main.ts"
-			if self.use_typescript
-			else f"{self.spa_name}/src/main.js"
-		)
+        # Install router and other npm packages
+        # yarn add vue-router@4 socket.io-client@4.5.1
+        print("Installing dependencies...")
+        subprocess.run(
+            ["yarn", "add", "vue-router@^4", "socket.io-client@^4.5.1"],
+            cwd=self.spa_path,
+        )
 
-		if main_js.exists():
-			with main_js.open("w") as f:
-				boilerplate = MAIN_JS_BOILERPLATE
+    def link_controller_files(self):
+        # Link controller files in main.js/main.ts
+        print("Linking controller files...")
+        main_js: Path = self.app_path / (
+            f"{self.spa_name}/src/main.ts"
+            if self.use_typescript
+            else f"{self.spa_name}/src/main.js"
+        )
 
-				# Add css import
-				if self.add_tailwindcss:
-					boilerplate = "import './index.css';\n" + boilerplate
+        if main_js.exists():
+            with main_js.open("w") as f:
+                boilerplate = MAIN_JS_BOILERPLATE
 
-				f.write(boilerplate)
-		else:
-			click.echo("src/main.js not found!")
-			return
+                # Add css import
+                if self.add_tailwindcss:
+                    boilerplate = "import './index.css';\n" + boilerplate
 
-	def setup_proxy_options(self):
-		# Setup proxy options file
-		proxy_options_file: Path = self.spa_path / (
-			"proxyOptions.ts" if self.use_typescript else "proxyOptions.js"
-		)
-		create_file(proxy_options_file, PROXY_OPTIONS_BOILERPLATE)
+                f.write(boilerplate)
+        else:
+            click.echo("src/main.js not found!")
+            return
 
-	def setup_vue_vite_config(self):
-		vite_config_file: Path = self.spa_path / (
-			"vite.config.ts" if self.use_typescript else "vite.config.js"
-		)
-		if not vite_config_file.exists():
-			vite_config_file.touch()
-		with vite_config_file.open("w") as f:
-			boilerplate = VUE_VITE_CONFIG_BOILERPLATE.replace("{{app}}", self.app)
-			boilerplate = boilerplate.replace("{{name}}", self.spa_name)
-			f.write(boilerplate)
+    def setup_proxy_options(self):
+        # Setup proxy options file
+        proxy_options_file: Path = self.spa_path / (
+            "proxyOptions.ts" if self.use_typescript else "proxyOptions.js"
+        )
+        create_file(proxy_options_file, PROXY_OPTIONS_BOILERPLATE)
 
-	def create_www_directory(self):
-		www_dir_path: Path = self.app_path / f"{self.app}/www"
+    def setup_vue_vite_config(self):
+        vite_config_file: Path = self.spa_path / (
+            "vite.config.ts" if self.use_typescript else "vite.config.js"
+        )
+        if not vite_config_file.exists():
+            vite_config_file.touch()
+        with vite_config_file.open("w") as f:
+            boilerplate = VUE_VITE_CONFIG_BOILERPLATE.replace("{{app}}", self.app)
+            boilerplate = boilerplate.replace("{{name}}", self.spa_name)
+            f.write(boilerplate)
 
-		if not www_dir_path.exists():
-			www_dir_path.mkdir()
+    def create_www_directory(self):
+        www_dir_path: Path = self.app_path / f"{self.app}/www"
 
-	def add_csrf_to_html(self):
-		index_html_file_path = self.spa_path / "index.html"
-		with index_html_file_path.open("r") as f:
-			current_html = f.read()
+        if not www_dir_path.exists():
+            www_dir_path.mkdir()
 
-		# For attaching CSRF Token
-		updated_html = current_html.replace(
-			"</div>", "</div>\n\t\t<script>window.csrf_token = '{{ frappe.session.csrf_token }}';</script>"
-		)
+    def add_csrf_to_html(self):
+        index_html_file_path = self.spa_path / "index.html"
+        with index_html_file_path.open("r") as f:
+            current_html = f.read()
 
-		with index_html_file_path.open("w") as f:
-			f.write(updated_html)
+        # For attaching CSRF Token
+        updated_html = current_html.replace(
+            "</div>",
+            "</div>\n\t\t<script>window.csrf_token = '{{ frappe.session.csrf_token }}';</script>",
+        )
 
-	def initialize_react_vite_project(self):
-		# Run "yarn create vite {name} --template react"
-		print("Scaffolding React project...")
-		if self.use_typescript:
-			subprocess.run(
-				["yarn", "create", "vite", self.spa_name, "--template", "react-ts"],
-				cwd=self.app_path,
-			)
-		else:
-			subprocess.run(
-				["yarn", "create", "vite", self.spa_name, "--template", "react"], cwd=self.app_path
-			)
+        with index_html_file_path.open("w") as f:
+            f.write(updated_html)
 
-		# Install router and other npm packages
-		# yarn add frappe-react-sdk socket.io-client@4.5.1
-		print("Installing dependencies...")
-		subprocess.run(
-			["yarn", "add", "frappe-react-sdk"], cwd=self.spa_path
-		)
+    def initialize_react_vite_project(self):
+        # Run "yarn create vite {name} --template react"
+        print("Scaffolding React project...")
+        if self.use_typescript:
+            subprocess.run(
+                ["yarn", "create", "vite", self.spa_name, "--template", "react-ts"],
+                cwd=self.app_path,
+            )
+        else:
+            subprocess.run(
+                ["yarn", "create", "vite", self.spa_name, "--template", "react"],
+                cwd=self.app_path,
+            )
 
-	def setup_react_vite_config(self):
-		vite_config_file: Path = self.spa_path / (
-			"vite.config.ts" if self.use_typescript else "vite.config.js"
-		)
-		if not vite_config_file.exists():
-			vite_config_file.touch()
-		with vite_config_file.open("w") as f:
-			boilerplate = REACT_VITE_CONFIG_BOILERPLATE.replace("{{app}}", self.app)
-			boilerplate = boilerplate.replace("{{name}}", self.spa_name)
-			f.write(boilerplate)
+        # Install router and other npm packages
+        # yarn add frappe-react-sdk socket.io-client@4.5.1
+        print("Installing dependencies...")
+        subprocess.run(["yarn", "add", "frappe-react-sdk"], cwd=self.spa_path)
 
-	def create_react_files(self):
-		app_react = self.spa_path / ("src/App.tsx" if self.use_typescript else "src/App.jsx")
-		create_file(app_react, APP_REACT_BOILERPLATE)
+    def setup_react_vite_config(self):
+        vite_config_file: Path = self.spa_path / (
+            "vite.config.ts" if self.use_typescript else "vite.config.js"
+        )
+        if not vite_config_file.exists():
+            vite_config_file.touch()
+        with vite_config_file.open("w") as f:
+            boilerplate = REACT_VITE_CONFIG_BOILERPLATE.replace("{{app}}", self.app)
+            boilerplate = boilerplate.replace("{{name}}", self.spa_name)
+            f.write(boilerplate)
+
+    def create_react_files(self):
+        app_react = self.spa_path / (
+            "src/App.tsx" if self.use_typescript else "src/App.jsx"
+        )
+        create_file(app_react, APP_REACT_BOILERPLATE)


### PR DESCRIPTION
bug fix for error while running add-spa command with --tailwindcss
bench add-spa --app changelog_claudion --tailwindcss


npm error A complete log of this run can be found in: /home/erpgulf/.npm/_logs/2025-08-01T14_23_51_581Z-debug-0.log
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/opt/alw/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 114, in <module>
    main()
  File "/opt/alw/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 20, in main
    click.Group(commands=commands)(prog_name="bench")
  File "/opt/alw/frappe-bench/env/lib/python3.10/site-packages/click/core.py", line 1442, in __call__
    return self.main(*args, **kwargs)
  File "/opt/alw/frappe-bench/env/lib/python3.10/site-packages/click/core.py", line 1363, in main
    rv = self.invoke(ctx)
  File "/opt/alw/frappe-bench/env/lib/python3.10/site-packages/click/core.py", line 1830, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/opt/alw/frappe-bench/env/lib/python3.10/site-packages/click/core.py", line 1830, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/opt/alw/frappe-bench/env/lib/python3.10/site-packages/click/core.py", line 1226, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/opt/alw/frappe-bench/env/lib/python3.10/site-packages/click/core.py", line 794, in invoke
    return callback(*args, **kwargs)
  File "/opt/alw/frappe-bench/apps/doppio/doppio/commands/__init__.py", line 35, in generate_spa
    generator.generate_spa()
  File "/opt/alw/frappe-bench/apps/doppio/doppio/commands/spa_generator.py", line 53, in generate_spa
    self.setup_tailwindcss()
  File "/opt/alw/frappe-bench/apps/doppio/doppio/commands/spa_generator.py", line 96, in setup_tailwindcss
    tailwind_config = tailwind_config_path.read_text()
  File "/usr/lib/python3.10/pathlib.py", line 1134, in read_text
    with self.open(mode='r', encoding=encoding, errors=errors) as f:
  File "/usr/lib/python3.10/pathlib.py", line 1119, in open
    return self._accessor.open(self, mode, buffering, encoding, errors,
FileNotFoundError: [Errno 2] No such file or directory: '../apps/changelog_claudion/dashboard2/tailwind.config.js'
