### PR TITLE
feat: support multiple SPA build scripts

### DIFF
--- a/doppio/commands/utils.py
+++ b/doppio/commands/utils.py
@@ -14,17 +14,29 @@ def create_file(path: Path, content: str | None = None):
 		with path.open("w") as f:
 			f.write(content)
 
+_LEGACY_CD_YARN = re.compile(
+	r"(?<!\()\bcd\s+(\S+)\s+&&\s+(yarn\s+[^&]+?)(?=\s+&&\s+cd\s|\s*$)"
+)
+
+
+def _normalize_existing_commands(existing: str) -> str:
+	return _LEGACY_CD_YARN.sub(
+		lambda m: f"(cd {m.group(1)} && {m.group(2).strip()})", existing
+	)
+
 
 def _append_command(existing: str | None, new_cmd: str) -> str:
 	if not existing:
 		return new_cmd
-	
+
+	existing = _normalize_existing_commands(existing)
+
 	norm_existing = " ".join(existing.split())
 	norm_new = " ".join(new_cmd.split())
-	
+
 	if norm_new in norm_existing:
 		return existing
-		
+
 	return f"{existing} && {new_cmd}"
 
 
@@ -36,7 +48,6 @@ def add_commands_to_root_package_json(app, spa_name):
 	if not package_json_path.exists():
 		print("package.json not found. Please manually update the build command.")
 		return
-
 
 	with package_json_path.open("r") as f:
 		data = json.load(f)
@@ -64,15 +75,15 @@ def add_commands_to_root_package_json(app, spa_name):
 	scripts = app_data["scripts"]
 
 	scripts["postinstall"] = _append_command(
-		scripts.get("postinstall"), f"cd {spa_name} && yarn install"
+		scripts.get("postinstall"), f"(cd {spa_name} && yarn install)"
 	)
 
 	scripts["build"] = _append_command(
-		scripts.get("build"), f"cd {spa_name} && yarn build"
+		scripts.get("build"), f"(cd {spa_name} && yarn build)"
 	)
 
 	scripts["dev"] = _append_command(
-		scripts.get("dev"), f"cd {spa_name} && yarn dev"
+		scripts.get("dev"), f"(cd {spa_name} && yarn dev)"
 	)
 
 	with app_package_json_path.open("w") as f:

--- a/doppio/commands/utils.py
+++ b/doppio/commands/utils.py
@@ -18,7 +18,8 @@ def create_file(path: Path, content: str | None = None):
 def _append_command(existing: str | None, new_cmd: str) -> str:
 	if not existing:
 		return new_cmd
-	if new_cmd in existing:
+	parts = [part.strip() for part in existing.split("&&")]
+	if new_cmd.strip() in parts:
 		return existing
 	return f"{existing} && {new_cmd}"
 
@@ -50,7 +51,7 @@ def add_commands_to_root_package_json(app, spa_name):
 	app_package_json_path: Path = app_path / "package.json"
 
 	if not app_package_json_path.exists():
-		subprocess.run(["npm", "init", "--yes"], cwd=app_path)
+		subprocess.run(["npm", "init", "--yes"], cwd=app_path, check=True)
 
 	with app_package_json_path.open("r") as f:
 		app_data = json.load(f)

--- a/doppio/commands/utils.py
+++ b/doppio/commands/utils.py
@@ -18,9 +18,13 @@ def create_file(path: Path, content: str | None = None):
 def _append_command(existing: str | None, new_cmd: str) -> str:
 	if not existing:
 		return new_cmd
-	parts = [part.strip() for part in existing.split("&&")]
-	if new_cmd.strip() in parts:
+	
+	norm_existing = " ".join(existing.split())
+	norm_new = " ".join(new_cmd.split())
+	
+	if norm_new in norm_existing:
 		return existing
+		
 	return f"{existing} && {new_cmd}"
 
 
@@ -65,6 +69,10 @@ def add_commands_to_root_package_json(app, spa_name):
 
 	scripts["build"] = _append_command(
 		scripts.get("build"), f"cd {spa_name} && yarn build"
+	)
+
+	scripts["dev"] = _append_command(
+		scripts.get("dev"), f"cd {spa_name} && yarn dev"
 	)
 
 	with app_package_json_path.open("w") as f:

--- a/doppio/commands/utils.py
+++ b/doppio/commands/utils.py
@@ -15,6 +15,14 @@ def create_file(path: Path, content: str | None = None):
 			f.write(content)
 
 
+def _append_command(existing: str | None, new_cmd: str) -> str:
+	if not existing:
+		return new_cmd
+	if new_cmd in existing:
+		return existing
+	return f"{existing} && {new_cmd}"
+
+
 def add_commands_to_root_package_json(app, spa_name):
 	app_path = Path("../apps") / app
 	spa_path: Path = app_path / spa_name
@@ -24,7 +32,7 @@ def add_commands_to_root_package_json(app, spa_name):
 		print("package.json not found. Please manually update the build command.")
 		return
 
-	data = {}
+
 	with package_json_path.open("r") as f:
 		data = json.load(f)
 
@@ -39,22 +47,27 @@ def add_commands_to_root_package_json(app, spa_name):
 	with package_json_path.open("w") as f:
 		json.dump(data, f, indent=2)
 
-	# Update app's package.json
 	app_package_json_path: Path = app_path / "package.json"
 
 	if not app_package_json_path.exists():
 		subprocess.run(["npm", "init", "--yes"], cwd=app_path)
 
-		data = {}
-		with app_package_json_path.open("r") as f:
-			data = json.load(f)
+	with app_package_json_path.open("r") as f:
+		app_data = json.load(f)
 
-		data["scripts"]["postinstall"] = f"cd {spa_name} && yarn install"
-		data["scripts"]["dev"] = f"cd {spa_name} && yarn dev"
-		data["scripts"]["build"] = f"cd {spa_name} && yarn build"
+	app_data.setdefault("scripts", {})
+	scripts = app_data["scripts"]
 
-		with app_package_json_path.open("w") as f:
-			json.dump(data, f, indent=2)
+	scripts["postinstall"] = _append_command(
+		scripts.get("postinstall"), f"cd {spa_name} && yarn install"
+	)
+
+	scripts["build"] = _append_command(
+		scripts.get("build"), f"cd {spa_name} && yarn build"
+	)
+
+	with app_package_json_path.open("w") as f:
+		json.dump(app_data, f, indent=2)
 
 
 def add_routing_rule_to_hooks(app, spa_name):


### PR DESCRIPTION
Closes #68

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved updates to the app’s `package.json` scripts so repeated runs avoid duplicating command fragments.
  * Added safer handling when the app’s `package.json` or `scripts` section is missing, including automatic initialization when absent.
  * Preserves existing `postinstall`, `build`, and `dev` script content while merging in required setup steps exactly once.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->